### PR TITLE
Fix engine type set on issues

### DIFF
--- a/src/main/java/com/blackducksoftware/integration/fortify/parser/BlackDuckConstants.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/parser/BlackDuckConstants.java
@@ -33,7 +33,10 @@ public class BlackDuckConstants {
 
     public static final String SCAN_LABEL = "Black Duck Hub Vulnerability Import";
 
-    public static final String BLACKDUCK_ENGINE_TYPE = "BLACKDUCK_ENGINE_TYPE";
+    /**
+     * Issue engine type. Must match engine-type in plugin.xml.
+     */
+    public static final String BLACKDUCK_ENGINE_TYPE = "BLACKDUCK";
 
     public static final String ISSUE_CATEGORY = "3rd Party Component";
 


### PR DESCRIPTION
The plugin declares generated engine type in its plugin.xml (BLACKDUCK).
The plugin API requires using the declared engine type on issues as
well. Using a different engine type is undefined behavior and it will be
enforced in Fortify software versions since 22.1.0.

This change won't cause behavioral change for older Fortify software
versions.